### PR TITLE
steward: federation governance policies (CI + descriptor requirements)

### DIFF
--- a/config/world_policies.yaml
+++ b/config/world_policies.yaml
@@ -11,3 +11,17 @@ policies:
     rule: No city may consume more than 30 percent of the shared federation message budget within one hour.
     enforcement: world_rate_limiter
     window_s: 3600
+
+  - id: federation_ci_required
+    rule: Federation repos must have CI that runs on pull_request. Repos without PR-triggered CI receive trust penalty.
+    enforcement: trust_penalty
+    trust_penalty: 0.2
+    verification: steward_diagnostic
+    remediation: agent_template_ci_workflow
+
+  - id: federation_descriptor_required
+    rule: Federation repos must have .well-known/agent-federation.json. Missing descriptor means invisible to the network.
+    enforcement: trust_penalty
+    trust_penalty: 0.3
+    verification: steward_diagnostic
+    remediation: steward_healer

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -13,7 +13,7 @@ def test_world_heartbeat_writes_world_state(tmp_path):
     assert path == output.resolve()
     assert state["summary"]["registered_cities"] == 1
     assert state["summary"]["founding_cities"] == 1
-    assert state["summary"]["active_policies"] == 3
+    assert state["summary"]["active_policies"] == 5  # 3 founding + 2 governance (CI, descriptor)
     assert state["warnings"] == ["missing_last_heartbeat:agent-city"]
     persisted = json.loads(output.read_text())
     assert persisted["world_id"] == "agent-world"


### PR DESCRIPTION
## World Policies Added

**federation_ci_required**: Repos must have CI on pull_request.
Trust penalty: -0.2 for non-compliance. Steward verifies via diagnostic.

**federation_descriptor_required**: Repos must have .well-known/agent-federation.json.
Trust penalty: -0.3. Steward healer can remediate.

These are trust-based — no force, no API hacking. Non-compliant
repos get lower trust, which means steward won't delegate tasks
to them or prioritize their healing.

0 LLM tokens.