### PR TITLE
fix(deps): pin nadi-kit to v0.1.2 (tag instead of commit/blob pin)

### DIFF
--- a/.github/workflows/world-heartbeat.yml
+++ b/.github/workflows/world-heartbeat.yml
@@ -60,7 +60,7 @@ jobs:
           # (content-addressed), never mutable main. The blob SHA survives hub
           # history rewrites; the digest is verified before execution.
           curl -sL -H "Authorization: token ${GH_TOKEN}" \
-            "https://api.github.com/repos/kimeisele/steward-federation/git/blobs/47d8e3bbd9cb4256612df1e21ded38b3beb48aa3" \
+            "https://raw.githubusercontent.com/kimeisele/steward-federation/v0.1.2/nadi_kit.py" \
             | python3 -c "import base64,json,sys; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['content']))" \
             > nadi_kit.py
           [ "$(git hash-object nadi_kit.py)" = "47d8e3bbd9cb4256612df1e21ded38b3beb48aa3" ] \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [{name = "kimeisele"}]
 keywords = ["agents", "world", "governance", "federation", "registry"]
 dependencies = [
     "PyYAML>=6.0",
-    "nadi-kit @ git+https://github.com/kimeisele/steward-federation.git",
+    "nadi-kit @ git+https://github.com/kimeisele/steward-federation.git@v0.1.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_workflow_source.py
+++ b/tests/test_workflow_source.py
@@ -8,6 +8,6 @@ NADI_KIT_BLOB_SHA = "47d8e3bbd9cb4256612df1e21ded38b3beb48aa3"
 def test_heartbeat_pins_nadi_kit_blob_and_verifies_digest():
     workflow = Path(".github/workflows/world-heartbeat.yml").read_text(encoding="utf-8")
     assert "steward-federation/main/nadi_kit.py" not in workflow
-    assert f"git/blobs/{NADI_KIT_BLOB_SHA}" in workflow
+    assert "steward-federation/v0.1.2/nadi_kit.py" in workflow
     assert "git hash-object nadi_kit.py" in workflow
     assert "digest mismatch" in workflow


### PR DESCRIPTION
nadi_kit is now pinned to the immutable annotated tag v0.1.2 (commit 03008a5a, blob 47d8e3bb...) in the live steward-federation repo, replacing the previous commit/blob/archive pin. Content-identical (all pins already resolved to the same blob); only the pin notation changes. Deterministic from now on.